### PR TITLE
Refactor Dockerfile and scripts for improved GCC installation and configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,27 +1,35 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-24.04
 
-# 基本パッケージ
+# ============================================================================
+# Stage 1: Base packages (cached separately)
+# ============================================================================
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates curl wget git build-essential \
     bash-completion unzip zip jq locales \
     && rm -rf /var/lib/apt/lists/*
 
-# ロケール & タイムゾーン
+# ============================================================================
+# Stage 2: Locale and timezone configuration
+# ============================================================================
 RUN sed -i 's/# *ja_JP.UTF-8/ja_JP.UTF-8/' /etc/locale.gen && locale-gen
 ENV LANG=ja_JP.UTF-8 LANGUAGE=ja_JP:ja LC_ALL=ja_JP.UTF-8
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
     && echo "Asia/Tokyo" > /etc/timezone
 ENV TZ=Asia/Tokyo
 
-# vscode ユーザーのホーム準備
+# ============================================================================
+# Stage 3: vscode user home setup
+# ============================================================================
 RUN mkdir -p /home/vscode/.local/bin \
     /home/vscode/.local/pipx \
     /home/vscode/.local/share/man \
  && chown -R vscode:vscode /home/vscode/.local
 
+# ============================================================================
+# Stage 4: Environment variables
+# ============================================================================
 USER vscode
 
-# pipx 用の環境変数と PATH
 ENV PIPX_HOME=/home/vscode/.local/pipx
 ENV PIPX_BIN_DIR=/home/vscode/.local/bin
 ENV PATH=/opt/atcoder/gcc/bin:/workspaces/atcoder:${PIPX_BIN_DIR}:${PATH}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,11 +42,12 @@
         }
     },
     "remoteUser": "vscode",
-    "updateContentCommand": "bash .devcontainer/scripts/install_pypy && bash .devcontainer/scripts/install_cpp && python3 -m pip install --user --no-cache-dir -r requirements.txt && chmod +x cpp_compile cpp_run",
+    "updateContentCommand": "(bash .devcontainer/scripts/install_pypy & bash .devcontainer/scripts/install_cpp) && python3 -m pip install --user --no-cache-dir -r requirements.txt && chmod +x cpp_compile cpp_run",
     "containerEnv": {
         "PIPX_BIN_DIR": "/home/vscode/.local/bin",
         "PIPX_HOME": "/home/vscode/.local/pipx",
         "PYPY_VERSION": "7.3.16",
+        "GCC_MAJOR_VERSION": "14",
         "AC_EXT_VERSION": "2.0.0",
         "ATCODER_CPP_INSTALL_DIR": "/opt/atcoder/gcc"
     },

--- a/.devcontainer/scripts/install_cpp
+++ b/.devcontainer/scripts/install_cpp
@@ -7,56 +7,40 @@ else
     SUDO=""
 fi
 
-AC_VARIANT="${AC_VARIANT:-gcc}"
 AC_INSTALL_DIR="${AC_INSTALL_DIR:-/opt/atcoder/gcc}"
-AC_TEMP_DIR="${AC_TEMP_DIR:-/tmp/atcoder/gcc}"
-GCC_VERSION="${GCC_VERSION:-15.2.0}"
 WORKSPACE_DIR="${WORKSPACE_DIR:-/workspaces/atcoder}"
-PARALLEL=$(( $(nproc) + 2 ))
+GCC_MAJOR_VERSION="${GCC_MAJOR_VERSION:-14}"
 
-echo "[install_cpp] variant=${AC_VARIANT} install_dir=${AC_INSTALL_DIR}"
+echo "[install_cpp] install_dir=${AC_INSTALL_DIR}, gcc_version=${GCC_MAJOR_VERSION}"
 
-${SUDO} rm -rf "${AC_TEMP_DIR}"
-${SUDO} mkdir -p "${AC_TEMP_DIR}" "${AC_INSTALL_DIR}"
-${SUDO} chown "$(id -u)":"$(id -g)" "${AC_TEMP_DIR}"
-
-echo "[install_cpp] installing prerequisites"
+# Create symlink from system GCC to /opt/atcoder/gcc for compatibility
+echo "[install_cpp] installing GCC ${GCC_MAJOR_VERSION} from Ubuntu repository"
 ${SUDO} apt-get update
 ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    git cmake lld ninja-build pigz \
-    build-essential bison flex libgmp-dev libmpfr-dev libmpc-dev libisl-dev texinfo \
-    wget ca-certificates xz-utils ccache
+    gcc-${GCC_MAJOR_VERSION} g++-${GCC_MAJOR_VERSION}
 ${SUDO} rm -rf /var/lib/apt/lists/*
 
-ENABLE_CCACHE=false
-if command -v ccache >/dev/null 2>&1; then
-    export CC="ccache gcc"
-    export CXX="ccache g++"
-    ENABLE_CCACHE=true
+# Create symlink for compatibility
+${SUDO} mkdir -p "${AC_INSTALL_DIR}"
+${SUDO} mkdir -p "${AC_INSTALL_DIR}/bin"
+${SUDO} ln -sf /usr/bin/gcc-${GCC_MAJOR_VERSION} "${AC_INSTALL_DIR}/bin/gcc"
+${SUDO} ln -sf /usr/bin/g++-${GCC_MAJOR_VERSION} "${AC_INSTALL_DIR}/bin/g++"
+${SUDO} ln -sf /usr/bin/gcc-${GCC_MAJOR_VERSION} "${AC_INSTALL_DIR}/bin/cc"
+
+# Create lib symlinks
+${SUDO} mkdir -p "${AC_INSTALL_DIR}/lib64"
+${SUDO} mkdir -p "${AC_INSTALL_DIR}/lib"
+if [ -d /usr/lib/gcc/x86_64-linux-gnu/${GCC_MAJOR_VERSION} ]; then
+    ${SUDO} ln -sf /usr/lib/gcc/x86_64-linux-gnu/${GCC_MAJOR_VERSION} "${AC_INSTALL_DIR}/lib64/${GCC_MAJOR_VERSION}"
+    ${SUDO} ln -sf /usr/lib/gcc/x86_64-linux-gnu/${GCC_MAJOR_VERSION} "${AC_INSTALL_DIR}/lib/${GCC_MAJOR_VERSION}"
 fi
-echo "[install_cpp] ccache enabled=${ENABLE_CCACHE}"
 
-GCC_ARCHIVE="gcc-${GCC_VERSION}.tar.xz"
-GCC_URL="https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/${GCC_ARCHIVE}"
-echo "[install_cpp] downloading GCC ${GCC_VERSION} from ${GCC_URL}"
-cd "${AC_TEMP_DIR}"
-wget -qO "${GCC_ARCHIVE}" "${GCC_URL}"
-tar -xf "${GCC_ARCHIVE}"
-mkdir -p "gcc-${GCC_VERSION}-build"
-cd "gcc-${GCC_VERSION}-build"
+${SUDO} mkdir -p /etc/atcoder
+echo "${AC_INSTALL_DIR}" | ${SUDO} tee /etc/atcoder/install_dir.txt >/dev/null
 
-"../gcc-${GCC_VERSION}/configure" \
-    --prefix="${AC_INSTALL_DIR}" \
-    --enable-languages=c,c++ \
-    --disable-multilib \
-    --enable-lto \
-    --with-isl
+echo "[install_cpp] completed: $("${AC_INSTALL_DIR}/bin/g++" --version | head -n 1)"
 
-echo "[install_cpp] building GCC (parallel=${PARALLEL})"
-make -j"${PARALLEL}"
-echo "[install_cpp] installing GCC"
-${SUDO} make -j"${PARALLEL}" install-strip
-
+# Create ac-library include directory
 ACLIB_SRC="${WORKSPACE_DIR}/ac-library"
 if [ -d "${ACLIB_SRC}" ]; then
     echo "[install_cpp] installing ac-library from ${ACLIB_SRC}"
@@ -68,17 +52,9 @@ else
     echo "[install_cpp] warning: ac-library not found at ${ACLIB_SRC}" >&2
 fi
 
-${SUDO} mkdir -p /etc/atcoder
-echo "${AC_INSTALL_DIR}" | ${SUDO} tee /etc/atcoder/install_dir.txt >/dev/null
-
-echo "[install_cpp] cleaning temp directory"
-${SUDO} rm -rf "${AC_TEMP_DIR}"
-
-echo "[install_cpp] completed: $("${AC_INSTALL_DIR}/bin/g++" --version | head -n 1)"
-
 # Precompile bits/stdc++.h with matching compiler flags
 echo "[install_cpp] precompiling bits/stdc++.h"
-STDC_HEADER=$(find "${AC_INSTALL_DIR}/include/c++/${GCC_VERSION}" -name "stdc++.h" -path "*/bits/stdc++.h" | head -n 1)
+STDC_HEADER=$(find /usr/include/c++/${GCC_MAJOR_VERSION} -name "stdc++.h" -path "*/bits/stdc++.h" 2>/dev/null | head -n 1)
 if [ -n "${STDC_HEADER}" ]; then
     STDC_DIR=$(dirname "${STDC_HEADER}")
     echo "[install_cpp] found stdc++.h at ${STDC_HEADER}"


### PR DESCRIPTION
This pull request refactors the C++ toolchain installation in the development container to simplify and speed up the build process. The main change is switching from building GCC from source to using the GCC package from the Ubuntu repository, improving maintainability and reducing setup time. Additionally, environment configuration and script structure have been improved for clarity and consistency.

**C++ Toolchain Installation Refactor:**
- Switched from compiling GCC from source to installing GCC and G++ via the Ubuntu package manager using the `GCC_MAJOR_VERSION` environment variable, and created symlinks in `/opt/atcoder/gcc` for compatibility. This greatly reduces build time and complexity.
- Updated the precompilation of `bits/stdc++.h` to use the system include path that matches the installed GCC version.

**Development Container Configuration:**
- Added `GCC_MAJOR_VERSION` as a configurable environment variable in `devcontainer.json` and updated the `updateContentCommand` to run C++ and PyPy installation scripts in parallel for faster setup.
- Improved the structure and documentation of the `.devcontainer/Dockerfile` by dividing it into clear stages and adding explanatory comments.